### PR TITLE
chore: Clarify hostname requirements, refactor examples to include extended capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # The version which will be reported by the --version argument of each binary
 # and which will be used as the Docker image tag
-VERSION ?= v1.0.4
+VERSION ?= latest
 # The Docker repository name, overridden in CI.
 DOCKER_REGISTRY ?= ghcr.io
 DOCKER_IMAGE_NAME ?= keyfactor/command-cert-manager-issuer

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The Issuer resource is namespaced, while the ClusterIssuer resource is cluster-s
 For example, ClusterIssuer resources can be used to issue certificates for resources in multiple namespaces, whereas Issuer resources can only be used to issue certificates for resources in the same namespace.
 
 The `spec` field of both the Issuer and ClusterIssuer resources use the following fields:
-* `hostname` - The hostname of the Keyfactor Command server
+* `hostname` - The hostname of the Keyfactor Command server - The signer sets the protocol to `https` and automatically trims the trailing path from the hostname. Additionally, the base Command API path is automatically set to `/KeyfactorAPI` and cannot be changed.
 * `commandSecretName` - The name of the Kubernetes `kubernetes.io/basic-auth` secret containing credentials to the Keyfactor instance
 * `certificateTemplate` - The short name corresponding to a template in Command that will be used to issue certificates.
 * `certificateAuthorityLogicalName` - The logical name of the CA to use to sign the certificate request

--- a/README.md
+++ b/README.md
@@ -45,42 +45,56 @@ kubectl get nodes
 
 ### Installation from Manifests
 
-Once Kubernetes is running, a static installation of cert-manager can be installed with the following command:
-```shell
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
-```
+1. Once Kubernetes is running, a static installation of cert-manager can be installed with the following command:
+    ```shell
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+    ```
 
-###### :pushpin: Running the static cert-manager configuration is not recommended for production use. For more information, see [Installing cert-manager](https://cert-manager.io/docs/installation/).
+    ###### :pushpin: Running the static cert-manager configuration is not recommended for production use. For more information, see [Installing cert-manager](https://cert-manager.io/docs/installation/).
 
-Then, install the custom resource definitions (CRDs) for the cert-manager external issuer for Keyfactor Command:
-```shell
-make install
-```
+2. Then, install the custom resource definitions (CRDs) for the cert-manager external issuer for Keyfactor Command:
+    ```shell
+    make install
+    ```
 
-Finally, deploy the controller to the cluster:
-```shell
-make deploy
-```
+3. Finally, deploy the controller to the cluster:
+    ```shell
+    make deploy
+    ```
 
 ### Installation from Helm Chart
 
 The cert-manager external issuer for Keyfactor Command can also be installed using a Helm chart. The chart is available in the [Command cert-manager Helm repository](https://keyfactor.github.io/command-cert-manager-issuer/).
 
-First, add the Helm repository:
-```bash
-helm repo add command-issuer https://keyfactor.github.io/command-cert-manager-issuer
-helm repo update
-```
+1. Add the Helm repository:
+    ```bash
+    helm repo add command-issuer https://keyfactor.github.io/command-cert-manager-issuer
+    helm repo update
+    ```
 
-Then, install the chart:
-```bash
-helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer
-```
+2. Then, install the chart:
+    ```bash
+    helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer
+    ```
 
-Modifications can be made by overriding the default values in the `values.yaml` file with the `--set` flag. For example, to override the `replicaCount` value, run the following command:
-```bash
-helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer --set replicaCount=2
-```
+    a. Modifications can be made by overriding the default values in the `values.yaml` file with the `--set` flag. For example, to override the `replicaCount` value, run the following command:
+
+        helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
+            --set replicaCount=2
+
+    b. Modifications can also be made by modifying the `values.yaml` file directly. For example, to override the
+    `replicaCount` value, modify the `replicaCount` value in the `values.yaml` file:
+
+        cat <<EOF > override.yaml
+        replicaCount: 2
+        EOF
+
+    Then, use the `-f` flag to specify the `values.yaml` file:
+    
+    ```yaml
+    helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
+        -f override.yaml
+    ```
 
 ## Usage
 The cert-manager external issuer for Keyfactor Command can be used to issue certificates from Keyfactor Command using cert-manager.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The Issuer resource is namespaced, while the ClusterIssuer resource is cluster-s
 For example, ClusterIssuer resources can be used to issue certificates for resources in multiple namespaces, whereas Issuer resources can only be used to issue certificates for resources in the same namespace.
 
 The `spec` field of both the Issuer and ClusterIssuer resources use the following fields:
-* `hostname` - The hostname of the Keyfactor Command server - The signer sets the protocol to `https` and automatically trims the trailing path from the hostname. Additionally, the base Command API path is automatically set to `/KeyfactorAPI` and cannot be changed.
+* `hostname` - The hostname of the Keyfactor Command server - The signer sets the protocol to `https` and automatically trims the trailing path from this field, if it exists. Additionally, the base Command API path is automatically set to `/KeyfactorAPI` and cannot be changed.
 * `commandSecretName` - The name of the Kubernetes `kubernetes.io/basic-auth` secret containing credentials to the Keyfactor instance
 * `certificateTemplate` - The short name corresponding to a template in Command that will be used to issue certificates.
 * `certificateAuthorityLogicalName` - The logical name of the CA to use to sign the certificate request

--- a/config/samples/certificate.yaml
+++ b/config/samples/certificate.yaml
@@ -2,6 +2,10 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: command-certificate
+  annotations:
+    command-issuer.keyfactor.com/certificateTemplate: "Ephemeral2day"
+    command-issuer.keyfactor.com/certificateAuthorityLogicalName: "InternalIssuingCA1"
+    metadata.command-issuer.keyfactor.com/ResponsibleTeam: "theResponsibleTeam@example.com"
 spec:
   commonName: command-issuer-sample
   secretName: command-certificate

--- a/config/samples/command-issuer_v1alpha1_clusterissuer.yaml
+++ b/config/samples/command-issuer_v1alpha1_clusterissuer.yaml
@@ -13,3 +13,4 @@ spec:
   certificateTemplate: ""
   certificateAuthorityLogicalName: ""
   certificateAuthorityHostname: ""
+  caSecretName: ""

--- a/config/samples/command-issuer_v1alpha1_issuer.yaml
+++ b/config/samples/command-issuer_v1alpha1_issuer.yaml
@@ -5,8 +5,12 @@ metadata:
     app.kubernetes.io/name: issuer
     app.kubernetes.io/instance: issuer-sample
     app.kubernetes.io/part-of: command-issuer
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: command-issuer
   name: issuer-sample
 spec:
-  # TODO(user): Add fields here
+  hostname: ""
+  commandSecretName: ""
+  certificateTemplate: ""
+  certificateAuthorityLogicalName: ""
+  certificateAuthorityHostname: ""
+  caSecretName: ""

--- a/deploy/charts/command-cert-manager-issuer/README.md
+++ b/deploy/charts/command-cert-manager-issuer/README.md
@@ -31,30 +31,43 @@ helm install command-cert-manager-issuer command-issuer/command-cert-manager-iss
 
 Modifications can be made by overriding the default values in the `values.yaml` file with the `--set` flag. For example, to override the `replicaCount` value, run the following command:
 ```bash
-helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer --set replicaCount=2
+helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
+    --set replicaCount=2
+```
+
+Modifications can also be made by modifying the `values.yaml` file directly. For example, to override the `replicaCount` value, modify the `replicaCount` value in the `values.yaml` file:
+```yaml
+cat <<EOF > override.yaml
+replicaCount: 2
+EOF
+```
+Then, use the `-f` flag to specify the `values.yaml` file:
+```bash
+helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
+    -f override.yaml
 ```
 
 ## Configuration
 
 The following table lists the configurable parameters of the `command-cert-manager-issuer` chart and their default values.
 
-| Parameter                         | Description                                           | Default                                                        |
-|-----------------------------------|-------------------------------------------------------|----------------------------------------------------------------|
-| `replicaCount`                    | Number of replica command-cert-manager-issuers to run | `1`                                                            |
-| `image.repository`                | Image repository                                      | `m8rmclarenkf/command-cert-manager-external-issuer-controller` |
-| `image.pullPolicy`                | Image pull policy                                     | `IfNotPresent`                                                 |
-| `image.tag`                       | Image tag                                             | `1.0.3`                                                        |
-| `imagePullSecrets`                | Image pull secrets                                    | `[]`                                                           |
-| `nameOverride`                    | Name override                                         | `""`                                                           |
-| `fullnameOverride`                | Full name override                                    | `""`                                                           |
-| `crd.create`                      | Specifies if CRDs will be created                     | `true`                                                         |
-| `crd.annotations`                 | Annotations to add to the CRD                         | `{}`                                                           |
-| `serviceAccount.create`           | Specifies if a service account should be created      | `true`                                                         |
-| `serviceAccount.annotations`      | Annotations to add to the service account             | `{}`                                                           |
-| `serviceAccount.name`             | Name of the service account to use                    | `""` (uses the fullname template if `create` is true)          |
-| `podAnnotations`                  | Annotations for the pod                               | `{}`                                                           |
-| `podSecurityContext.runAsNonRoot` | Run pod as non-root                                   | `true`                                                         |
-| `securityContext`                 | Security context for the pod                          | `{}` (with commented out options)                              |
-| `resources`                       | CPU/Memory resource requests/limits                   | `{}` (with commented out options)                              |
-| `nodeSelector`                    | Node labels for pod assignment                        | `{}`                                                           |
-| `tolerations`                     | Tolerations for pod assignment                        | `[]`                                                           |
+| Parameter                         | Description                                           | Default                                               |
+|-----------------------------------|-------------------------------------------------------|-------------------------------------------------------|
+| `replicaCount`                    | Number of replica command-cert-manager-issuers to run | `1`                                                   |
+| `image.repository`                | Image repository                                      | `ghcr.io/keyfactor/command-cert-manager-issuer`       |
+| `image.pullPolicy`                | Image pull policy                                     | `IfNotPresent`                                        |
+| `image.tag`                       | Image tag                                             | `""`                                                  |
+| `imagePullSecrets`                | Image pull secrets                                    | `[]`                                                  |
+| `nameOverride`                    | Name override                                         | `""`                                                  |
+| `fullnameOverride`                | Full name override                                    | `""`                                                  |
+| `crd.create`                      | Specifies if CRDs will be created                     | `true`                                                |
+| `crd.annotations`                 | Annotations to add to the CRD                         | `{}`                                                  |
+| `serviceAccount.create`           | Specifies if a service account should be created      | `true`                                                |
+| `serviceAccount.annotations`      | Annotations to add to the service account             | `{}`                                                  |
+| `serviceAccount.name`             | Name of the service account to use                    | `""` (uses the fullname template if `create` is true) |
+| `podAnnotations`                  | Annotations for the pod                               | `{}`                                                  |
+| `podSecurityContext.runAsNonRoot` | Run pod as non-root                                   | `true`                                                |
+| `securityContext`                 | Security context for the pod                          | `{}` (with commented out options)                     |
+| `resources`                       | CPU/Memory resource requests/limits                   | `{}` (with commented out options)                     |
+| `nodeSelector`                    | Node labels for pod assignment                        | `{}`                                                  |
+| `tolerations`                     | Tolerations for pod assignment                        | `[]`                                                  |


### PR DESCRIPTION
Clarify README.md to explicitly detail `hostname` requirements:

The `spec` field of both the Issuer and ClusterIssuer resources use the following fields:
* `hostname` - The hostname of the Keyfactor Command server - The signer sets the protocol to `https` and automatically trims the trailing path from this field, if it exists. Additionally, the base Command API path is automatically set to `/KeyfactorAPI` and cannot be changed.
* `commandSecretName` - The name of the Kubernetes `kubernetes.io/basic-auth` secret containing credentials to the Keyfactor instance
* `certificateTemplate` - The short name corresponding to a template in Command that will be used to issue certificates.
* `certificateAuthorityLogicalName` - The logical name of the CA to use to sign the certificate request
* `certificateAuthorityHostname` - The CAs hostname to use to sign the certificate request
* `caSecretName` - The name of the Kubernetes secret containing the CA certificate. This field is optional and only required if the Command server is configured to use a self-signed certificate or with a certificate signed by an untrusted root.