### PR TITLE
V1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,12 @@
 * fix(helm): Signer Helm Chart now includes a `secureMetrics` value to enable/disable sidecar RBAC container for further protection of the `/metrics` endpoint.
 * fix(signer): Signer now returns CA chain bytes instead of appending to the leaf certificate.
 * fix(role): Removed permissions for `configmaps` resource types for the `leader-election-role` role.
+
+# v1.0.5
+
+## Features
+* feat(controller): Implement Kubernetes `client-go` REST client for Secret/ConfigMap retrieval to bypass `controller-runtime` caching system. This enables the reconciler to retrieve Secret and ConfigMap resources at the namespace scope with only namespace-level permissions.
+
+## Fixes
+* fix(helm): Add configuration flag to configure chart to either grant cluster-scoped or namespace-scoped access to Secret and ConfigMap API
+* fix(controller): Add logic to read secret from reconciler namespace or Issuer namespace depending on Helm configuration.

--- a/api/v1alpha1/clusterissuer_types.go
+++ b/api/v1alpha1/clusterissuer_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api/v1alpha1/issuer_types.go
+++ b/api/v1alpha1/issuer_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/deploy/charts/command-cert-manager-issuer/README.md
+++ b/deploy/charts/command-cert-manager-issuer/README.md
@@ -18,32 +18,46 @@ The Command external issuer for cert-manager allows users to enroll certificates
 
 ### Add Helm Repository
 
-```bash
+```shell
 helm repo add command-issuer https://keyfactor.github.io/command-cert-manager-issuer
 helm repo update
 ```
 
 ### Install Chart
 
-```bash
-helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer
-```
-
-Modifications can be made by overriding the default values in the `values.yaml` file with the `--set` flag. For example, to override the `replicaCount` value, run the following command:
-```bash
+```shell
 helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
-    --set replicaCount=2
+    --namespace command-issuer-system \
+    --create-namespace \
+    --set image.repository=<your container registry>/keyfactor/command-cert-manager-issuer \
+    --set image.tag=<tag> \
+    --set crd.create=true \
+    # --set image.pullPolicy=Never # Only required if using a local image
 ```
 
-Modifications can also be made by modifying the `values.yaml` file directly. For example, to override the `replicaCount` value, modify the `replicaCount` value in the `values.yaml` file:
+Modifications can be made by overriding the default values in the `values.yaml` file with the `--set` flag. For example, to override the `secretConfig.useClusterRoleForSecretAccess` to configure the chart to use a cluster role for secret access, run the following command:
+
+```shell
+helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
+    --namespace command-issuer-system \
+    --create-namespace \
+    --set image.repository=<your container registry>/keyfactor/command-cert-manager-issuer \
+    --set image.tag=<tag> \
+    --set crd.create=true \
+    --set secretConfig.useClusterRoleForSecretAccess=true
+```
+
+Modifications can also be made by modifying the `values.yaml` file directly. For example, to override the `secretConfig.useClusterRoleForSecretAccess` value to configure the chart to use a cluster role for secret access, modify the `secretConfig.useClusterRoleForSecretAccess` value in the `values.yaml` file by creating an override file:
 ```yaml
 cat <<EOF > override.yaml
-replicaCount: 2
+secretConfig:
+    useClusterRoleForSecretAccess: true
 EOF
 ```
 Then, use the `-f` flag to specify the `values.yaml` file:
-```bash
+```shell
 helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
+    --namespace command-issuer-system \
     -f override.yaml
 ```
 
@@ -51,23 +65,25 @@ helm install command-cert-manager-issuer command-issuer/command-cert-manager-iss
 
 The following table lists the configurable parameters of the `command-cert-manager-issuer` chart and their default values.
 
-| Parameter                         | Description                                           | Default                                               |
-|-----------------------------------|-------------------------------------------------------|-------------------------------------------------------|
-| `replicaCount`                    | Number of replica command-cert-manager-issuers to run | `1`                                                   |
-| `image.repository`                | Image repository                                      | `ghcr.io/keyfactor/command-cert-manager-issuer`       |
-| `image.pullPolicy`                | Image pull policy                                     | `IfNotPresent`                                        |
-| `image.tag`                       | Image tag                                             | `""`                                                  |
-| `imagePullSecrets`                | Image pull secrets                                    | `[]`                                                  |
-| `nameOverride`                    | Name override                                         | `""`                                                  |
-| `fullnameOverride`                | Full name override                                    | `""`                                                  |
-| `crd.create`                      | Specifies if CRDs will be created                     | `true`                                                |
-| `crd.annotations`                 | Annotations to add to the CRD                         | `{}`                                                  |
-| `serviceAccount.create`           | Specifies if a service account should be created      | `true`                                                |
-| `serviceAccount.annotations`      | Annotations to add to the service account             | `{}`                                                  |
-| `serviceAccount.name`             | Name of the service account to use                    | `""` (uses the fullname template if `create` is true) |
-| `podAnnotations`                  | Annotations for the pod                               | `{}`                                                  |
-| `podSecurityContext.runAsNonRoot` | Run pod as non-root                                   | `true`                                                |
-| `securityContext`                 | Security context for the pod                          | `{}` (with commented out options)                     |
-| `resources`                       | CPU/Memory resource requests/limits                   | `{}` (with commented out options)                     |
-| `nodeSelector`                    | Node labels for pod assignment                        | `{}`                                                  |
-| `tolerations`                     | Tolerations for pod assignment                        | `[]`                                                  |
+| Parameter                                    | Description                                                                                                                              | Default                                               |
+|----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| `replicaCount`                               | Number of replica command-cert-manager-issuers to run                                                                                    | `1`                                                   |
+| `image.repository`                           | Image repository                                                                                                                         | `ghcr.io/keyfactor/command-cert-manager-issuer`       |
+| `image.pullPolicy`                           | Image pull policy                                                                                                                        | `IfNotPresent`                                        |
+| `image.tag`                                  | Image tag                                                                                                                                | `""`                                                  |
+| `imagePullSecrets`                           | Image pull secrets                                                                                                                       | `[]`                                                  |
+| `nameOverride`                               | Name override                                                                                                                            | `""`                                                  |
+| `fullnameOverride`                           | Full name override                                                                                                                       | `""`                                                  |
+| `crd.create`                                 | Specifies if CRDs will be created                                                                                                        | `true`                                                |
+| `crd.annotations`                            | Annotations to add to the CRD                                                                                                            | `{}`                                                  |
+| `serviceAccount.create`                      | Specifies if a service account should be created                                                                                         | `true`                                                |
+| `serviceAccount.annotations`                 | Annotations to add to the service account                                                                                                | `{}`                                                  |
+| `serviceAccount.name`                        | Name of the service account to use                                                                                                       | `""` (uses the fullname template if `create` is true) |
+| `podAnnotations`                             | Annotations for the pod                                                                                                                  | `{}`                                                  |
+| `podSecurityContext.runAsNonRoot`            | Run pod as non-root                                                                                                                      | `true`                                                |
+| `securityContext`                            | Security context for the pod                                                                                                             | `{}` (with commented out options)                     |
+| `resources`                                  | CPU/Memory resource requests/limits                                                                                                      | `{}` (with commented out options)                     |
+| `nodeSelector`                               | Node labels for pod assignment                                                                                                           | `{}`                                                  |
+| `tolerations`                                | Tolerations for pod assignment                                                                                                           | `[]`                                                  |
+| `secureMetrics.enabled`                      | Whether to enable and configure the kube-rbac-proxy sidecar for authorized and authenticated use of the /metrics endpoint by Prometheus. | `false`                                               |
+| `secretConfig.useClusterRoleForSecretAccess` | Specifies if the ServiceAccount should be granted access to the Secret resource using a ClusterRole                                      | `false`                                               |

--- a/deploy/charts/command-cert-manager-issuer/templates/clusterrole.yaml
+++ b/deploy/charts/command-cert-manager-issuer/templates/clusterrole.yaml
@@ -6,14 +6,6 @@ metadata:
   name: {{ include "command-cert-manager-issuer.name" . }}-manager-role
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - cert-manager.io
     resources:
       - certificaterequests

--- a/deploy/charts/command-cert-manager-issuer/templates/deployment.yaml
+++ b/deploy/charts/command-cert-manager-issuer/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=127.0.0.1:8080
             - --leader-elect
+            {{- if .Values.secretConfig.useClusterRoleForSecretAccess}}
+            - --secret-access-granted-at-cluster-level
+            {{- end}}
           command:
             - /manager
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/deploy/charts/command-cert-manager-issuer/templates/secretrole.yaml
+++ b/deploy/charts/command-cert-manager-issuer/templates/secretrole.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ if .Values.secretConfig.useClusterRoleForSecretAccess }}ClusterRole{{ else }}Role{{ end }}
+metadata:
+  labels:
+    {{- include "command-cert-manager-issuer.labels" . | nindent 4 }}
+  name: {{ include "command-cert-manager-issuer.name" . }}-secret-reader-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ if .Values.secretConfig.useClusterRoleForSecretAccess }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}
+metadata:
+  labels:
+    {{- include "command-cert-manager-issuer.labels" . | nindent 4 }}
+  name: {{ include "command-cert-manager-issuer.name" . }}-secret-reader-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ if .Values.secretConfig.useClusterRoleForSecretAccess }}ClusterRole{{ else }}Role{{ end }}
+  name: {{ include "command-cert-manager-issuer.name" . }}-secret-reader-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "command-cert-manager-issuer.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/deploy/charts/command-cert-manager-issuer/values.yaml
+++ b/deploy/charts/command-cert-manager-issuer/values.yaml
@@ -18,6 +18,16 @@ fullnameOverride: ""
 secureMetrics:
   enabled: false
 
+secretConfig:
+  # If true, when using Issuer resources, the credential secret must be created in the same namespace as the
+  # Issuer resource. This access is facilitated by granting the ServiceAccount [get, list, watch] for the secret
+  # API at the cluster level.
+  #
+  # If false, both Issuer and ClusterIssuer must reference a secret in the same namespace as the chart/reconciler.
+  # This access is facilitated by granting the ServiceAccount [get, list, watch] for the secret API only for the
+  # namespace the chart is deployed in.
+  useClusterRoleForSecretAccess: false
+
 crd:
   # Specifies whether CRDs will be created
   create: true

--- a/docs/config_usage.markdown
+++ b/docs/config_usage.markdown
@@ -27,7 +27,7 @@ cat <<EOF >> metadata.json
         {
             "AllowAPI": true,
             "DataType": 1,
-            "Description": "The namespace that the issuer resource was created in.",
+            "Description": "The namespace that the issuer resource was created in that .",
             "Name": "Issuer-Namespace"
         },
         {
@@ -83,6 +83,7 @@ kfutil import --metadata --file metadata.json
 
 ### Authentication
 Authentication to the Command platform is done using basic authentication. The credentials must be provided as a Kubernetes `kubernetes.io/basic-auth` secret. These credentials should be for a user with "Certificate Enrollment: Enroll CSR" and "API: Read" permissions in Command.
+If the Helm chart was deployed with the `--set "secretConfig.useClusterRoleForSecretAccess=true"` flag, the secret must be created in the same namespace as any Issuer resources deployed. Otherwise, the secret must be created in the same namespace as the controller.
 
 Create a `kubernetes.io/basic-auth` secret with the Keyfactor Command username and password:
 ```shell

--- a/docs/install.markdown
+++ b/docs/install.markdown
@@ -42,7 +42,7 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 
 The cert-manager external issuer for Keyfactor Command is distributed as source code, and the container must be built manually. The container image can be built using the following command:
 ```shell
-make docker-build DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=keyfactor/command-cert-manager-issuer
+make docker-build DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=keyfactor/command-cert-manager-issuer VERSION=<tag>
 ```
 
 ###### :pushpin: The container image can be built using Docker Buildx by running `make docker-buildx`. This will build the image for all supported platforms.
@@ -50,7 +50,7 @@ make docker-build DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=ke
 To push the container image to a container registry, run the following command:
 ```shell
 docker login <your container registry>
-make docker-push DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=keyfactor/command-cert-manager-issuer
+make docker-push DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=keyfactor/command-cert-manager-issuer VERSION=<tag>
 ```
 
 ### Installation from Manifests
@@ -66,7 +66,7 @@ The cert-manager external issuer for Keyfactor Command can be installed using th
 2. Finally, deploy the controller to the cluster:
 
     ```shell
-    make deploy DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=keyfactor/command-cert-manager-issuer
+    make deploy DOCKER_REGISTRY=<your container registry> DOCKER_IMAGE_NAME=keyfactor/command-cert-manager-issuer VERSION=<tag>
     ```
 
 ### Installation from Helm Chart
@@ -75,51 +75,54 @@ The cert-manager external issuer for Keyfactor Command can also be installed usi
 
 1. Add the Helm repository:
     
-    ```bash
+    ```shell
     helm repo add command-issuer https://keyfactor.github.io/command-cert-manager-issuer
     helm repo update
     ```
 
 2. Then, install the chart:
     
-    ```bash
-    helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
-        --namespace command-issuer-system \
-        --create-namespace \
-        --set image.repository=<your container registry>/keyfactor/command-cert-manager-issuer \
-        --set image.tag=<tag>
-        # --set image.pullPolicy=Never # Only required if using a local image
-    ```
-
-    a. Modifications can be made by overriding the default values in the `values.yaml` file with the `--set` flag. For example, to override the `replicaCount` value, run the following command:
-
     ```shell
     helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
         --namespace command-issuer-system \
         --create-namespace \
         --set image.repository=<your container registry>/keyfactor/command-cert-manager-issuer \
-        --set image.tag=<tag>
-        --set replicaCount=2
+        --set image.tag=<tag> \
+        --set crd.create=true \
+        # --set image.pullPolicy=Never # Only required if using a local image
     ```
 
-    b. Modifications can also be made by modifying the `values.yaml` file directly. For example, to override the
-    `replicaCount` value, modify the `replicaCount` value in the `values.yaml` file:
+    1. Modifications can be made by overriding the default values in the `values.yaml` file with the `--set` flag. For example, to override the `secretConfig.useClusterRoleForSecretAccess` to configure the chart to use a cluster role for secret access, run the following command:
 
-    ```yaml
-    cat <<EOF > override.yaml
-    image:
-        repository: <your container registry>/keyfactor/command-cert-manager-issuer
-        pullPolicy: Never
-        tag: "latest"
-    replicaCount: 2
-    EOF
-    ```
+        ```shell
+        helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
+            --namespace command-issuer-system \
+            --create-namespace \
+            --set image.repository=<your container registry>/keyfactor/command-cert-manager-issuer \
+            --set image.tag=<tag> \
+            --set crd.create=true \
+            --set secretConfig.useClusterRoleForSecretAccess=true
+        ```
 
-    Then, use the `-f` flag to specify the `values.yaml` file:
-        
-    ```yaml
-    helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
-        -f override.yaml
-    ```
+    2. Modifications can also be made by modifying the `values.yaml` file directly. For example, to override the `secretConfig.useClusterRoleForSecretAccess` value to configure the chart to use a cluster role for secret access, modify the `secretConfig.useClusterRoleForSecretAccess` value in the `values.yaml` file by creating an override file:
+
+        ```yaml
+        cat <<EOF > override.yaml
+        image:
+            repository: <your container registry>/keyfactor/command-cert-manager-issuer
+            pullPolicy: Never
+            tag: "<tag>"
+        secretConfig:
+            useClusterRoleForSecretAccess: true
+        EOF
+        ```
+
+        Then, use the `-f` flag to specify the `values.yaml` file:
+
+        ```shell
+        helm install command-cert-manager-issuer command-issuer/command-cert-manager-issuer \
+            --namespace command-issuer-system \
+            -f override.yaml
+        ```
 
 Next, complete the [Usage](config_usage.markdown) steps to configure the cert-manager external issuer for Keyfactor Command.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	k8s.io/client-go v0.26.3
+	k8s.io/klog/v2 v2.90.1
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	sigs.k8s.io/controller-runtime v0.14.6
 )
@@ -72,7 +73,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.3 // indirect
 	k8s.io/component-base v0.26.3 // indirect
-	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-aggregator v0.26.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20230327201221-f5883ff37f0c // indirect
 	sigs.k8s.io/gateway-api v0.6.2 // indirect

--- a/internal/controllers/certificaterequest_controller_test.go
+++ b/internal/controllers/certificaterequest_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	cmgen "github.com/cert-manager/cert-manager/test/unit/gen"
-	logrtesting "github.com/go-logr/logr/testing"
+	logrtesting "github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -602,15 +602,17 @@ func TestCertificateRequestReconcile(t *testing.T) {
 				WithObjects(tc.objects...).
 				Build()
 			controller := CertificateRequestReconciler{
-				Client:                   fakeClient,
-				Scheme:                   scheme,
-				ClusterResourceNamespace: tc.clusterResourceNamespace,
-				SignerBuilder:            tc.Builder,
-				CheckApprovedCondition:   true,
-				Clock:                    fixedClock,
+				Client:                            fakeClient,
+				ConfigClient:                      NewFakeConfigClient(fakeClient),
+				Scheme:                            scheme,
+				ClusterResourceNamespace:          tc.clusterResourceNamespace,
+				SignerBuilder:                     tc.Builder,
+				CheckApprovedCondition:            true,
+				Clock:                             fixedClock,
+				SecretAccessGrantedAtClusterLevel: true,
 			}
 			result, err := controller.Reconcile(
-				ctrl.LoggerInto(context.TODO(), logrtesting.NewTestLogger(t)),
+				ctrl.LoggerInto(context.TODO(), logrtesting.New(t)),
 				reconcile.Request{NamespacedName: tc.name},
 			)
 			if tc.expectedError != nil {

--- a/internal/controllers/fake_configclient_test.go
+++ b/internal/controllers/fake_configclient_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright © 2023 Keyfactor
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"github.com/Keyfactor/command-issuer/internal/issuer/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FakeConfigClient is a fake implementation of the util.ConfigClient interface
+// It forwards requests destined for the Kubernetes API server implemented by
+// the util.ConfigClient interface to a fake Kubernetes API server implemented
+// by the client.Client interface.
+
+// Force the compiler to check that FakeConfigClient implements the util.ConfigClient interface
+var _ util.ConfigClient = &FakeConfigClient{}
+
+type FakeConfigClient struct {
+	client client.Client
+	ctx    context.Context
+}
+
+// NewFakeConfigClient uses the
+func NewFakeConfigClient(fakeControllerRuntimeClient client.Client) util.ConfigClient {
+	return &FakeConfigClient{
+		client: fakeControllerRuntimeClient,
+	}
+}
+
+func (f *FakeConfigClient) SetContext(ctx context.Context) {
+	f.ctx = ctx
+}
+
+func (f *FakeConfigClient) GetConfigMap(name types.NamespacedName, out *corev1.ConfigMap) error {
+	return f.client.Get(f.ctx, name, out)
+}
+
+func (f *FakeConfigClient) GetSecret(name types.NamespacedName, out *corev1.Secret) error {
+	return f.client.Get(f.ctx, name, out)
+}

--- a/internal/controllers/issuer_controller_test.go
+++ b/internal/controllers/issuer_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"github.com/Keyfactor/command-issuer/internal/issuer/signer"
 	issuerutil "github.com/Keyfactor/command-issuer/internal/issuer/util"
-	logrtesting "github.com/go-logr/logr/testing"
+	logrtesting "github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -126,7 +126,7 @@ func TestIssuerReconcile(t *testing.T) {
 			expectedReadyConditionStatus: commandissuer.ConditionTrue,
 			expectedResult:               ctrl.Result{RequeueAfter: defaultHealthCheckInterval},
 		},
-		"issuer-kind-unrecognised": {
+		"issuer-kind-Unrecognized": {
 			kind: "UnrecognizedType",
 			name: types.NamespacedName{Namespace: "ns1", Name: "issuer1"},
 		},
@@ -251,14 +251,16 @@ func TestIssuerReconcile(t *testing.T) {
 				tc.kind = "Issuer"
 			}
 			controller := IssuerReconciler{
-				Kind:                     tc.kind,
-				Client:                   fakeClient,
-				Scheme:                   scheme,
-				HealthCheckerBuilder:     tc.healthCheckerBuilder,
-				ClusterResourceNamespace: tc.clusterResourceNamespace,
+				Kind:                              tc.kind,
+				Client:                            fakeClient,
+				ConfigClient:                      NewFakeConfigClient(fakeClient),
+				Scheme:                            scheme,
+				HealthCheckerBuilder:              tc.healthCheckerBuilder,
+				ClusterResourceNamespace:          tc.clusterResourceNamespace,
+				SecretAccessGrantedAtClusterLevel: true,
 			}
 			result, err := controller.Reconcile(
-				ctrl.LoggerInto(context.TODO(), logrtesting.NewTestLogger(t)),
+				ctrl.LoggerInto(context.TODO(), logrtesting.New(t)),
 				reconcile.Request{NamespacedName: tc.name},
 			)
 			if tc.expectedError != nil {

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/issuer/signer/signer_test.go
+++ b/internal/issuer/signer/signer_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/issuer/util/configclient.go
+++ b/internal/issuer/util/configclient.go
@@ -1,0 +1,164 @@
+/*
+Copyright © 2023 Keyfactor
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+	authv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// ConfigClient is an interface for a K8s REST client.
+type ConfigClient interface {
+	SetContext(ctx context.Context)
+	GetConfigMap(name types.NamespacedName, out *corev1.ConfigMap) error
+	GetSecret(name types.NamespacedName, out *corev1.Secret) error
+}
+
+type configClient struct {
+	ctx         context.Context
+	logger      klog.Logger
+	client      kubernetes.Interface
+	accessCache map[string]bool
+
+	verifyAccessFunc func(apiResource string, resource types.NamespacedName) error
+}
+
+// NewConfigClient creates a new K8s REST client using the configuration from the controller-runtime.
+func NewConfigClient(ctx context.Context) (ConfigClient, error) {
+	config := ctrl.GetConfigOrDie()
+
+	// Create the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	client := &configClient{
+		client:      clientset,
+		accessCache: make(map[string]bool),
+		ctx:         ctx,
+		logger:      klog.NewKlogr(),
+	}
+
+	client.verifyAccessFunc = client.verifyAccessToResource
+
+	return client, nil
+}
+
+// SetContext sets the context for the client.
+func (c *configClient) SetContext(ctx context.Context) {
+	c.ctx = ctx
+	c.logger = klog.FromContext(ctx)
+}
+
+// verifyAccessToResource verifies that the client has access to a given resource in a given namespace
+// by creating a SelfSubjectAccessReview. This is done to avoid errors when the client does not have
+// access to the resource.
+func (c *configClient) verifyAccessToResource(apiResource string, resource types.NamespacedName) error {
+	verbs := []string{"get", "list", "watch"}
+
+	for _, verb := range verbs {
+		ssar := &authv1.SelfSubjectAccessReview{
+			Spec: authv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authv1.ResourceAttributes{
+					Name:      resource.Name,
+					Namespace: resource.Namespace,
+
+					Group:    "",
+					Resource: apiResource,
+					Verb:     verb,
+				},
+			},
+		}
+
+		ssar, err := c.client.AuthorizationV1().SelfSubjectAccessReviews().Create(c.ctx, ssar, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to create SelfSubjectAccessReview to check access to %s for verb %q: %w", apiResource, verb, err)
+		}
+
+		if !ssar.Status.Allowed {
+			return fmt.Errorf("client does not have access to %s called %q for verb %q, reason: %v", apiResource, resource.String(), verb, ssar.Status.String())
+		}
+	}
+
+	c.logger.Info(fmt.Sprintf("Client has access to %s called %q", apiResource, resource.String()))
+
+	return nil
+}
+
+// GetConfigMap gets the configmap with the given name and namespace and copies it into the out parameter.
+func (c *configClient) GetConfigMap(name types.NamespacedName, out *corev1.ConfigMap) error {
+	if c == nil {
+		return fmt.Errorf("config client is nil")
+	}
+
+	// Check if the client has access to the configmap resource
+	if _, ok := c.accessCache[name.String()]; !ok {
+		// If this is the first time the client is accessing the resource and it does have
+		// permission, add it to the access cache so that it does not need to be checked again.
+		err := c.verifyAccessFunc("configmaps", name)
+		if err != nil {
+			return err
+		}
+		c.accessCache[name.String()] = true
+	}
+
+	// Get the configmap
+	configmap, err := c.client.CoreV1().ConfigMaps(name.Namespace).Get(c.ctx, name.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Copy the configmap into the out parameter
+	configmap.DeepCopyInto(out)
+	return nil
+}
+
+// GetSecret gets the secret with the given name and namespace and copies it into the out parameter.
+func (c *configClient) GetSecret(name types.NamespacedName, out *corev1.Secret) error {
+	if c == nil {
+		return fmt.Errorf("config client is nil")
+	}
+
+	// Check if the client has access to the secret resource
+	if _, ok := c.accessCache[name.String()]; !ok {
+		// If this is the first time the client is accessing the resource and it does have
+		// permission, add it to the access cache so that it does not need to be checked again.
+		err := c.verifyAccessFunc("secrets", name)
+		if err != nil {
+			return err
+		}
+		c.accessCache[name.String()] = true
+	}
+
+	// Get the secret
+	secret, err := c.client.CoreV1().Secrets(name.Namespace).Get(c.ctx, name.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Copy the secret into the out parameter
+	secret.DeepCopyInto(out)
+	return nil
+}

--- a/internal/issuer/util/configclient_test.go
+++ b/internal/issuer/util/configclient_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright © 2023 Keyfactor
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	logrtesting "github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"testing"
+)
+
+func TestConfigClient(t *testing.T) {
+	var err error
+
+	// Define namespaced names for test objects
+	configMapName := types.NamespacedName{Name: "test-configmap", Namespace: "default"}
+	secretName := types.NamespacedName{Name: "test-secret", Namespace: "default"}
+
+	// Create and inject fake ConfigMap
+	testConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: configMapName.Name, Namespace: configMapName.Namespace},
+	}
+
+	// Create and inject fake Secret
+	testSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: secretName.Name, Namespace: secretName.Namespace},
+	}
+
+	// Create a fake clientset with the test objects
+	clientset := fake.NewSimpleClientset([]runtime.Object{
+		testConfigMap,
+		testSecret,
+	}...)
+
+	// We can't test NewConfigClient unless we can mock ctrl.GetConfigOrDie() and kubernetes.NewForConfig()
+	// So we'll just test the methods that use the clientset
+
+	// Create a ConfigClient
+	client := &configClient{
+		client:      clientset,
+		accessCache: make(map[string]bool),
+	}
+
+	// The fake client doesn't implement authorization.k8s.io/v1 SelfSubjectAccessReview
+	// So we'll mock the verifyAccessFunc
+	client.verifyAccessFunc = func(apiResource string, resource types.NamespacedName) error {
+		return nil
+	}
+
+	// Setup logging for test environment by setting the context
+	client.SetContext(ctrl.LoggerInto(context.TODO(), logrtesting.New(t)))
+
+	t.Run("GetConfigMap", func(t *testing.T) {
+		// Test GetConfigMap
+		var out corev1.ConfigMap
+		err = client.GetConfigMap(configMapName, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, testConfigMap, &out)
+	})
+
+	t.Run("GetSecret", func(t *testing.T) {
+		// Test GetSecret
+		var out corev1.Secret
+		err = client.GetSecret(secretName, &out)
+		assert.NoError(t, err)
+		assert.Equal(t, testSecret, &out)
+	})
+}

--- a/internal/issuer/util/util.go
+++ b/internal/issuer/util/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import (
 
 const inClusterNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 
+// GetSpecAndStatus is a helper function that returns the Spec and Status of an Issuer object.
 func GetSpecAndStatus(issuer client.Object) (*commandissuer.IssuerSpec, *commandissuer.IssuerStatus, error) {
 	switch t := issuer.(type) {
 	case *commandissuer.Issuer:
@@ -40,6 +41,7 @@ func GetSpecAndStatus(issuer client.Object) (*commandissuer.IssuerSpec, *command
 	}
 }
 
+// SetReadyCondition is a helper function that sets the Ready condition on an IssuerStatus.
 func SetReadyCondition(status *commandissuer.IssuerStatus, conditionStatus commandissuer.ConditionStatus, reason, message string) {
 	ready := GetReadyCondition(status)
 	if ready == nil {
@@ -64,6 +66,7 @@ func SetReadyCondition(status *commandissuer.IssuerStatus, conditionStatus comma
 	}
 }
 
+// GetReadyCondition is a helper function that returns the Ready condition from an IssuerStatus.
 func GetReadyCondition(status *commandissuer.IssuerStatus) *commandissuer.IssuerCondition {
 	for _, c := range status.Conditions {
 		if c.Type == commandissuer.IssuerConditionReady {
@@ -73,6 +76,7 @@ func GetReadyCondition(status *commandissuer.IssuerStatus) *commandissuer.Issuer
 	return nil
 }
 
+// IsReady is a helper function that returns true if the Ready condition is set to True.
 func IsReady(status *commandissuer.IssuerStatus) bool {
 	if c := GetReadyCondition(status); c != nil {
 		return c.Status == commandissuer.ConditionTrue

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Keyfactor Command Authors.
+Copyright © 2023 Keyfactor
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"github.com/Keyfactor/command-issuer/internal/controllers"
 	"github.com/Keyfactor/command-issuer/internal/issuer/signer"
 	"github.com/Keyfactor/command-issuer/internal/issuer/util"
@@ -62,6 +64,7 @@ func main() {
 	var clusterResourceNamespace string
 	var printVersion bool
 	var disableApprovedCheck bool
+	var secretAccessGrantedAtClusterLevel bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -72,6 +75,8 @@ func main() {
 	flag.BoolVar(&printVersion, "version", false, "Print version to stdout and exit")
 	flag.BoolVar(&disableApprovedCheck, "disable-approved-check", false,
 		"Disables waiting for CertificateRequests to have an approved condition before signing.")
+	flag.BoolVar(&secretAccessGrantedAtClusterLevel, "secret-access-granted-at-cluster-level", false,
+		"Set this flag to true if the secret access is granted at cluster level. This will allow the controller to access secrets in any namespace. ")
 
 	opts := zap.Options{
 		Development: true,
@@ -92,6 +97,18 @@ func main() {
 			}
 			os.Exit(1)
 		}
+	}
+
+	if secretAccessGrantedAtClusterLevel {
+		setupLog.Info("expecting secret access at cluster level")
+	} else {
+		setupLog.Info(fmt.Sprintf("expecting secret access at namespace level (%s)", clusterResourceNamespace))
+	}
+
+	ctx := context.Background()
+	configClient, err := util.NewConfigClient(ctx)
+	if err != nil {
+		setupLog.Error(err, "error creating config client")
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -119,32 +136,38 @@ func main() {
 	}
 
 	if err = (&controllers.IssuerReconciler{
-		Kind:                     "Issuer",
-		Client:                   mgr.GetClient(),
-		Scheme:                   mgr.GetScheme(),
-		ClusterResourceNamespace: clusterResourceNamespace,
-		HealthCheckerBuilder:     signer.CommandHealthCheckerFromIssuerAndSecretData,
+		Kind:                              "Issuer",
+		Client:                            mgr.GetClient(),
+		ConfigClient:                      configClient,
+		Scheme:                            mgr.GetScheme(),
+		ClusterResourceNamespace:          clusterResourceNamespace,
+		SecretAccessGrantedAtClusterLevel: secretAccessGrantedAtClusterLevel,
+		HealthCheckerBuilder:              signer.CommandHealthCheckerFromIssuerAndSecretData,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Issuer")
 		os.Exit(1)
 	}
 	if err = (&controllers.IssuerReconciler{
-		Kind:                     "ClusterIssuer",
-		Client:                   mgr.GetClient(),
-		Scheme:                   mgr.GetScheme(),
-		ClusterResourceNamespace: clusterResourceNamespace,
-		HealthCheckerBuilder:     signer.CommandHealthCheckerFromIssuerAndSecretData,
+		Kind:                              "ClusterIssuer",
+		Client:                            mgr.GetClient(),
+		ConfigClient:                      configClient,
+		Scheme:                            mgr.GetScheme(),
+		ClusterResourceNamespace:          clusterResourceNamespace,
+		SecretAccessGrantedAtClusterLevel: secretAccessGrantedAtClusterLevel,
+		HealthCheckerBuilder:              signer.CommandHealthCheckerFromIssuerAndSecretData,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterIssuer")
 		os.Exit(1)
 	}
 	if err = (&controllers.CertificateRequestReconciler{
-		Client:                   mgr.GetClient(),
-		Scheme:                   mgr.GetScheme(),
-		ClusterResourceNamespace: clusterResourceNamespace,
-		SignerBuilder:            signer.CommandSignerFromIssuerAndSecretData,
-		CheckApprovedCondition:   !disableApprovedCheck,
-		Clock:                    clock.RealClock{},
+		Client:                            mgr.GetClient(),
+		Scheme:                            mgr.GetScheme(),
+		ConfigClient:                      configClient,
+		ClusterResourceNamespace:          clusterResourceNamespace,
+		SignerBuilder:                     signer.CommandSignerFromIssuerAndSecretData,
+		CheckApprovedCondition:            !disableApprovedCheck,
+		SecretAccessGrantedAtClusterLevel: secretAccessGrantedAtClusterLevel,
+		Clock:                             clock.RealClock{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CertificateRequest")
 		os.Exit(1)


### PR DESCRIPTION
Add configuration field to Helm chart that changes the scope of the ServiceAccount to grant cluster access to the K8s Secrets API.

```yaml
secretConfig:
  # If true, when using Issuer resources, the credential secret must be created in the same namespace as the
  # Issuer resource. This access is facilitated by granting the ServiceAccount [get, list, watch] for the secret
  # API at the cluster level.
  #
  # If false, both Issuer and ClusterIssuer must reference a secret in the same namespace as the chart/reconciler.
  # This access is facilitated by granting the ServiceAccount [get, list, watch] for the secret API only for the
  # namespace the chart is deployed in.
  useClusterRoleForSecretAccess: false
```

# v1.0.5 Changelog

## Features
* feat(controller): Implement Kubernetes `client-go` REST client for Secret/ConfigMap retrieval to bypass `controller-runtime` caching system. This enables the reconciler to retrieve Secret and ConfigMap resources at the namespace scope with only namespace-level permissions.

## Fixes
* fix(helm): Add configuration flag to configure chart to either grant cluster-scoped or namespace-scoped access to Secret and ConfigMap API
* fix(controller): Add logic to read secret from reconciler namespace or Issuer namespace depending on Helm configuration.