### PR TITLE
Set workflow version to 3.2.0

### DIFF
--- a/.github/workflows/keyfactor-bootstrap-workflow.yml
+++ b/.github/workflows/keyfactor-bootstrap-workflow.yml
@@ -46,12 +46,13 @@ jobs:
         run: go test -v ./...
 
   call-starter-workflow:
-    uses: keyfactor/actions/.github/workflows/starter.yml@v4
+    uses: keyfactor/actions/.github/workflows/starter.yml@3.2.0
     needs: test
     secrets:
       token: ${{ secrets.V2BUILDTOKEN}}
       gpg_key: ${{ secrets.KF_GPG_PRIVATE_KEY }}
       gpg_pass: ${{ secrets.KF_GPG_PASSPHRASE }}
+      APPROVE_README_PUSH: ${{ secrets.APPROVE_README_PUSH}}
       scan_token: ${{ secrets.SAST_TOKEN }}
       docker-user: ${{ secrets.DOCKER_USER }}
       docker-token:  ${{ secrets.DOCKER_PWD }}


### PR DESCRIPTION
Reverts change to set the workflow version to the latest `v4` tag, as we are having issues with the latest workflow version parsing the integrations-manifest file.

https://github.com/Keyfactor/command-cert-manager-issuer/actions/runs/18014873631/job/51257309589

https://github.com/Keyfactor/command-cert-manager-issuer/pull/51/files#diff-c5e7c2b69a8b0be46fb4cf4c0482eab828da929dd264bc55c7027b9603fe26b2L49