### PR TITLE
feat: Add volume and volume mount for service token

### DIFF
--- a/deploy/charts/command-cert-manager-issuer/templates/deployment.yaml
+++ b/deploy/charts/command-cert-manager-issuer/templates/deployment.yaml
@@ -28,6 +28,16 @@ spec:
       serviceAccountName: {{ include "command-cert-manager-issuer.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if not .Values.serviceAccount.automountServiceAccountToken }}
+      volumes:
+        - name: serviceaccount-token
+          projected:
+            defaultMode: {{ .Values.serviceAccount.projectedTokenVolume.defaultMode }}
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: {{ .Values.serviceAccount.projectedTokenVolume.expirationSeconds }}
+                  path: token
+      {{- end }}
       containers:
         - args:
             - --health-probe-bind-address=:8081
@@ -57,6 +67,12 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if not .Values.serviceAccount.automountServiceAccountToken }}
+          volumeMounts:
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: serviceaccount-token
+              readOnly: true
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/command-cert-manager-issuer/templates/serviceaccount.yaml
+++ b/deploy/charts/command-cert-manager-issuer/templates/serviceaccount.yaml
@@ -12,4 +12,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/deploy/charts/command-cert-manager-issuer/values.yaml
+++ b/deploy/charts/command-cert-manager-issuer/values.yaml
@@ -39,6 +39,15 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Specifies whether to automount the service account token
+  # If false, a projected volume will be used to mount the token
+  automountServiceAccountToken: false
+  # Configuration for projected service account token volume (used when automountServiceAccountToken is false)
+  projectedTokenVolume:
+    # Token expiration time in seconds
+    expirationSeconds: 3607
+    # File permissions for the token
+    defaultMode: 0444
 
 podLabels: {}
 


### PR DESCRIPTION
## Changes Made
1. `values.yaml:42-50`

Added configuration options:
- `serviceAccount.automountServiceAccountToken: false` (default)
- `serviceAccount.projectedTokenVolume.expirationSeconds: 3607`
- `serviceAccount.projectedTokenVolume.defaultMode: 0444`

2. `serviceaccount.yaml:15`

Added `automountServiceAccountToken` field that respects the values.yaml setting

3. `deployment.yaml:31-40`

Added conditional projected volume for service account token when `automountServiceAccountToken` is false

4. `deployment.yaml:70-75`

Added conditional volumeMount to mount the projected token at the standard location

## How It Works
When `serviceAccount.automountServiceAccountToken` is set to `false`:
- The ServiceAccount explicitly disables automatic token mounting
- A projected volume is created with a time-bound service account token
- The token is mounted at `/var/run/secrets/kubernetes.io/serviceaccount` (standard location)
- The token expires after 3607 seconds and is automatically rotated by Kubernetes

This approach provides better security by:
- Using short-lived tokens instead of permanent ones
- Maintaining compatibility with applications expecting tokens at the standard path
- Supporting the `automountServiceAccountToken: false` security requirement